### PR TITLE
Added spotless code formatter

### DIFF
--- a/.github/workflows/runnerdog.yml
+++ b/.github/workflows/runnerdog.yml
@@ -1,9 +1,5 @@
 name: reviewdog
-on:
-  push:
-    branches: [ main ]
-  pull_request:
-    branches: [ main ]
+on: [pull_request]
 jobs:
   checkstyle:
     name: runner / checkstyle

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -26,5 +26,22 @@
       }
     },
   ],
-  "java.test.defaultConfig": "WPIlibUnitTests"
+  "java.test.defaultConfig": "WPIlibUnitTests",
+
+  #################################
+  # Gradle Spotless Configuration #
+  #################################
+  "java.format.enabled": false,
+  "files.trimTrailingWhitespace": false,
+  "spotlessGradle.diagnostics.enable": true,
+  "spotlessGradle.format.enable": true,
+  "editor.codeActionsOnSave": {
+    "source.fixAll.spotlessGradle": true
+  },
+  "[java]": {
+    "editor.defaultFormatter": "richardwillis.vscode-spotless-gradle"
+  },
+  "[gradle]": {
+    "editor.defaultFormatter": "richardwillis.vscode-spotless-gradle"
+  }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -4,6 +4,7 @@ plugins {
     id "java"
     id "edu.wpi.first.GradleRIO" version "2023.1.1"
     id "idea"
+    id 'com.diffplug.spotless' version '6.12.0'
 }
 
 def javaVersion = JavaVersion.VERSION_11
@@ -110,5 +111,48 @@ idea {
         // Improve development experience (and IDEA's capabilities) by having source & javadoc attached
         downloadJavadoc = true
         downloadSources = true
+    }
+}
+
+spotless {
+    java {
+        target fileTree('.') {
+            include '**/*.java'
+            exclude '**/build/**', '**/build-*/**'
+        }
+        toggleOffOn()
+        googleJavaFormat()
+        removeUnusedImports()
+        trimTrailingWhitespace()
+        endWithNewline()
+    }
+    groovyGradle {
+        target fileTree('.') {
+            include '**/*.gradle'
+            exclude '**/build/**', '**/build-*/**'
+        }
+        greclipse()
+        indentWithSpaces(4)
+        trimTrailingWhitespace()
+        endWithNewline()
+    }
+    format 'xml', {
+        target fileTree('.') {
+            include '**/*.xml'
+            exclude '**/build/**', '**/build-*/**'
+        }
+        eclipseWtp('xml')
+        trimTrailingWhitespace()
+        indentWithSpaces(2)
+        endWithNewline()
+    }
+    format 'misc', {
+        target fileTree('.') {
+            include '**/*.md', '**/.gitignore'
+            exclude '**/build/**', '**/build-*/**'
+        }
+        trimTrailingWhitespace()
+        indentWithSpaces(2)
+        endWithNewline()
     }
 }


### PR DESCRIPTION
https://docs.wpilib.org/en/stable/docs/software/advanced-gradlerio/code-formatting.htmlSpotless

Spotless seems to be the "standard" code formatter for WPILib Java and appears to be the same as Google.  wpiformat seems to be for C++.  This commit just enables running:

./gradlew spotlessCheck - will check modified files and report diffs of formatting suggestions
./gradlew spotlessApply - applies formatting to all files in project (let's avoid this)

Eventually, we can add the "spotlessCheck" as part of the pull_request and get rid of reviewdog/checkstyle etc.