### PR TITLE
Moved sysId related constants to Constants.SysIdConstants.

### DIFF
--- a/src/main/java/bhs/devilbotz/Constants.java
+++ b/src/main/java/bhs/devilbotz/Constants.java
@@ -74,53 +74,6 @@ public final class Constants {
     /** The gear ratio of the encoder to the drive shaft */
     public static final int ENCODER_GEAR_RATIO = 1; // Encoder is connected directly to drive shaft
 
-    // Drive PID values TODO: Tune
-    /** The P value for the PID controller for the drive train. Gotten from SYSID */
-    public static final double DRIVE_P = 3.5725;
-    /** The I value for the PID controller for the drive train. Gotten from SYSID */
-    public static final double DRIVE_I = 0.0;
-    /** The D value for the PID controller for the drive train. Gotten from SYSID */
-    public static final double DRIVE_D = 0.0;
-
-    // Feedforward constants (straight-line) TODO: Tune
-    /**
-     * The S value for the feedforward controller for the drive train. Gotten from SYSID This is the
-     * static friction of the robot in a straight line.
-     */
-    public static final double DRIVE_FFS = 0.94143;
-    /**
-     * The V value for the feedforward controller for the drive train. Gotten from SYSID This is the
-     * velocity gain of the robot in a straight line.
-     */
-    public static final double DRIVE_FFV = 2.3803;
-    /**
-     * The A value for the feedforward controller for the drive train. Gotten from SYSID This is the
-     * acceleration gain of the robot in a straight line.
-     */
-    public static final double DRIVE_FFA = 0.48128;
-
-    // Feedforward constants (rotating) TODO: Tune
-    /**
-     * The S value for the feedforward controller for the drive train. Gotten from SYSID This is the
-     * static friction of the robot when rotating.
-     */
-    public static final double DRIVE_ANGULAR_FFS = 1.5;
-    /**
-     * The V value for the feedforward controller for the drive train. Gotten from SYSID This is the
-     * velocity gain of the robot when rotating.
-     */
-    public static final double DRIVE_ANGULAR_FFV = 3;
-    /**
-     * The A value for the feedforward controller for the drive train. Gotten from SYSID This is the
-     * acceleration gain of the robot when rotating.
-     */
-    public static final double DRIVE_ANGULAR_FFA = 0.3;
-
-    /** Create a linear system from our system identification gains. */
-    public static final LinearSystem<N2, N2, N2> DRIVE_PLANT =
-        LinearSystemId.identifyDrivetrainSystem(
-            DRIVE_FFV, DRIVE_FFA, DRIVE_ANGULAR_FFV, DRIVE_ANGULAR_FFA);
-
     /** Dual Talon SRX CIM motors on each side of drive train */
     public static final DCMotor MOTOR_CONFIGURATION = DCMotor.getCIM(2);
 
@@ -145,5 +98,86 @@ public final class Constants {
     public static final int GRIPPER_SOLENOID_FORWARD = 0;
     /** The gripper double solenoid reverse channel */
     public static final int GRIPPER_SOLENOID_REVERSE = 1;
+  }
+
+  /**
+   * These SysId constants are based on sysid_data20230127-205712.json TODO: Retune These With Final
+   * Robot
+   */
+  public static final class SysIdConstants {
+    /** The maximum speed of the robot in meters per second */
+    public static final double MAX_SPEED = 2.447; // meters per second
+    /** The maximum angular speed of the robot in radians per second */
+    public static final double MAX_ANGULAR_SPEED = 2 * Math.PI; // one rotation per second
+
+    /** The P value for the PID controller for the drive train (velocity). */
+    public static final double LEFT_FEED_BACK_VELOCITY_P = 3.5725;
+    /** The I value for the PID controller for the drive train (velocity). */
+    public static final double LEFT_FEED_BACK_VELOCITY_I = 0.0;
+    /** The D value for the PID controller for the drive train (velocity). */
+    public static final double LEFT_FEED_BACK_VELOCITY_D = 0.0;
+
+    /** The P value for the PID controller for the drive train (velocity). */
+    public static final double RIGHT_FEED_BACK_VELOCITY_P = 3.5725;
+    /** The I value for the PID controller for the drive train (velocity). */
+    public static final double RIGHT_FEED_BACK_VELOCITY_I = 0.0;
+    /** The D value for the PID controller for the drive train (velocity). */
+    public static final double RIGHT_FEED_BACK_VELOCITY_D = 0.0;
+
+    /** The P value for the PID controller for the drive train (position). */
+    public static final double LEFT_FEED_BACK_POSITION_P = 94.989;
+    /** The I value for the PID controller for the drive train (position). */
+    public static final double LEFT_FEED_BACK_POSITION_I = 0.0;
+    /** The D value for the PID controller for the drive train (position). */
+    public static final double LEFT_FEED_BACK_POSITION_D = 8.7272;
+
+    /** The P value for the PID controller for the drive train (position). */
+    public static final double RIGHT_FEED_BACK_POSITION_P = 94.989;
+    /** The I value for the PID controller for the drive train (position). */
+    public static final double RIGHT_FEED_BACK_POSITION_I = 0.0;
+    /** The D value for the PID controller for the drive train (position). */
+    public static final double RIGHT_FEED_BACK_POSITION_D = 8.7272;
+
+    // Feedforward constants (straight-line)
+    /**
+     * The S value for the feedforward controller for the drive train. This is the static friction
+     * of the robot in a straight line.
+     */
+    public static final double FEED_FORWARD_LINEAR_S = 0.94143;
+    /**
+     * The V value for the feedforward controller for the drive train. This is the velocity gain of
+     * the robot in a straight line.
+     */
+    public static final double FEED_FORWARD_LINEAR_V = 2.3803;
+    /**
+     * The A value for the feedforward controller for the drive train. This is the acceleration gain
+     * of the robot in a straight line.
+     */
+    public static final double FEED_FORWARD_LINEAR_A = 0.48128;
+
+    // Feedforward constants (rotating) TODO: Tune
+    /**
+     * The S value for the feedforward controller for the drive train. This is the static friction
+     * of the robot when rotating.
+     */
+    public static final double FEED_FORWARD_ANGULAR_S = 1.5;
+    /**
+     * The V value for the feedforward controller for the drive train. This is the velocity gain of
+     * the robot when rotating.
+     */
+    public static final double FEED_FORWARD_ANGULAR_V = 1.5;
+    /**
+     * The A value for the feedforward controller for the drive train.This is the acceleration gain
+     * of the robot when rotating.
+     */
+    public static final double FEED_FORWARD_ANGULAR_A = 0.3;
+
+    /** Create a linear system from our system identification gains. */
+    public static final LinearSystem<N2, N2, N2> PLANT =
+        LinearSystemId.identifyDrivetrainSystem(
+            FEED_FORWARD_LINEAR_V,
+            FEED_FORWARD_LINEAR_A,
+            FEED_FORWARD_ANGULAR_V,
+            FEED_FORWARD_ANGULAR_A);
   }
 }

--- a/src/main/java/bhs/devilbotz/subsystems/DriveTrain.java
+++ b/src/main/java/bhs/devilbotz/subsystems/DriveTrain.java
@@ -1,7 +1,7 @@
 package bhs.devilbotz.subsystems;
 
-import bhs.devilbotz.Constants;
 import bhs.devilbotz.Constants.DriveConstants;
+import bhs.devilbotz.Constants.SysIdConstants;
 import bhs.devilbotz.utils.ShuffleboardManager;
 import com.ctre.phoenix.motorcontrol.InvertType;
 import com.ctre.phoenix.motorcontrol.NeutralMode;
@@ -53,18 +53,18 @@ public class DriveTrain extends SubsystemBase {
   // These are used to control the speed of the motors proportionally to the speed of the wheels.
   private final PIDController leftPIDController =
       new PIDController(
-          Constants.DriveConstants.DRIVE_P,
-          Constants.DriveConstants.DRIVE_I,
-          Constants.DriveConstants.DRIVE_D);
+          SysIdConstants.LEFT_FEED_BACK_VELOCITY_P,
+          SysIdConstants.LEFT_FEED_BACK_VELOCITY_I,
+          SysIdConstants.LEFT_FEED_BACK_VELOCITY_D);
   private final PIDController rightPIDController =
       new PIDController(
-          Constants.DriveConstants.DRIVE_P,
-          Constants.DriveConstants.DRIVE_I,
-          Constants.DriveConstants.DRIVE_D);
+          SysIdConstants.RIGHT_FEED_BACK_VELOCITY_P,
+          SysIdConstants.RIGHT_FEED_BACK_VELOCITY_I,
+          SysIdConstants.RIGHT_FEED_BACK_VELOCITY_D);
 
   // Defines the kinematics of the drive train, which is used to calculate the speed of the wheels.
   private final DifferentialDriveKinematics kinematics =
-      new DifferentialDriveKinematics(Constants.DriveConstants.TRACK_WIDTH);
+      new DifferentialDriveKinematics(DriveConstants.TRACK_WIDTH);
 
   // Defines the odometry of the drive train, which is used to calculate the position of the robot.
   private final DifferentialDriveOdometry odometry;
@@ -73,9 +73,9 @@ public class DriveTrain extends SubsystemBase {
   // move the robot.
   private final SimpleMotorFeedforward feedforward =
       new SimpleMotorFeedforward(
-          Constants.DriveConstants.DRIVE_FFS,
-          Constants.DriveConstants.DRIVE_FFV,
-          Constants.DriveConstants.DRIVE_FFA);
+          SysIdConstants.FEED_FORWARD_LINEAR_S,
+          SysIdConstants.FEED_FORWARD_LINEAR_V,
+          SysIdConstants.FEED_FORWARD_LINEAR_A);
 
   // Defines the field, which is used to display the robot's position on the field in Shuffleboard.
   private final Field2d field = new Field2d();
@@ -98,11 +98,11 @@ public class DriveTrain extends SubsystemBase {
   private DifferentialDrivetrainSim differentialDriveSim =
       new DifferentialDrivetrainSim(
           // Create a linear system from our identification gains.
-          Constants.DriveConstants.DRIVE_PLANT,
-          Constants.DriveConstants.MOTOR_CONFIGURATION,
-          Constants.DriveConstants.MOTOR_GEAR_RATIO,
-          Constants.DriveConstants.TRACK_WIDTH,
-          Constants.DriveConstants.WHEEL_RADIUS,
+          SysIdConstants.PLANT,
+          DriveConstants.MOTOR_CONFIGURATION,
+          DriveConstants.MOTOR_GEAR_RATIO,
+          DriveConstants.TRACK_WIDTH,
+          DriveConstants.WHEEL_RADIUS,
 
           // The standard deviations for measurement noise:
           // x and y:          0.001 m
@@ -273,10 +273,7 @@ public class DriveTrain extends SubsystemBase {
    */
   private double getLeftDistance() {
     return leftMaster.getSelectedSensorPosition()
-        * (2
-            * Math.PI
-            * Constants.DriveConstants.WHEEL_RADIUS
-            / Constants.DriveConstants.ENCODER_RESOLUTION);
+        * (2 * Math.PI * DriveConstants.WHEEL_RADIUS / DriveConstants.ENCODER_RESOLUTION);
   }
 
   /**
@@ -288,10 +285,7 @@ public class DriveTrain extends SubsystemBase {
    */
   private double getRightDistance() {
     return rightMaster.getSelectedSensorPosition()
-        * (2
-            * Math.PI
-            * Constants.DriveConstants.WHEEL_RADIUS
-            / Constants.DriveConstants.ENCODER_RESOLUTION);
+        * (2 * Math.PI * DriveConstants.WHEEL_RADIUS / DriveConstants.ENCODER_RESOLUTION);
   }
 
   /**
@@ -302,10 +296,7 @@ public class DriveTrain extends SubsystemBase {
    */
   private double getLeftVelocity() {
     return leftMaster.getSelectedSensorVelocity()
-        * (2
-            * Math.PI
-            * Constants.DriveConstants.WHEEL_RADIUS
-            / Constants.DriveConstants.ENCODER_RESOLUTION);
+        * (2 * Math.PI * DriveConstants.WHEEL_RADIUS / DriveConstants.ENCODER_RESOLUTION);
   }
 
   /**
@@ -316,10 +307,7 @@ public class DriveTrain extends SubsystemBase {
    */
   private double getRightVelocity() {
     return rightMaster.getSelectedSensorVelocity()
-        * (2
-            * Math.PI
-            * Constants.DriveConstants.WHEEL_RADIUS
-            / Constants.DriveConstants.ENCODER_RESOLUTION);
+        * (2 * Math.PI * DriveConstants.WHEEL_RADIUS / DriveConstants.ENCODER_RESOLUTION);
   }
 
   /**


### PR DESCRIPTION
Hi Parker,

I re-organized all of the sysId related constants to a separate sub-class so that it's clear where the values came from and which values we need to re-generate with the final robot.  It will also facilitate supporting multiple robots using the same code base.  E.g. we can have an array of SysIdConstants if we want to support both the practice and competition bot in the same code base.

I also separated out the LEFT vs RIGHT Velocity PIDs.

There isn't any functional change with this PR.