### PR TITLE
Allow user to set robot position in simulation on field

### DIFF
--- a/src/main/java/bhs/devilbotz/Robot.java
+++ b/src/main/java/bhs/devilbotz/Robot.java
@@ -89,7 +89,9 @@ public class Robot extends TimedRobot {
 
   /** This method is called once each time the robot enters Disabled mode. */
   @Override
-  public void disabledInit() {}
+  public void disabledInit() {
+    robotContainer.driveTrain.resetRobotPosition();
+  }
 
   @Override
   public void disabledPeriodic() {}
@@ -97,6 +99,8 @@ public class Robot extends TimedRobot {
   /** This autonomous runs the autonomous command selected by your {@link RobotContainer} class. */
   @Override
   public void autonomousInit() {
+    robotContainer.driveTrain.resetRobotPosition();
+
     autonomousCommand = robotContainer.getAutonomousCommand(autoMode);
     Gripper.enableCompressor();
 
@@ -112,6 +116,8 @@ public class Robot extends TimedRobot {
 
   @Override
   public void teleopInit() {
+    robotContainer.driveTrain.resetRobotPosition();
+
     // This makes sure that the autonomous stops running when
     // teleop starts running. If you want the autonomous to
     // continue until interrupted by another command, remove

--- a/src/main/java/bhs/devilbotz/RobotContainer.java
+++ b/src/main/java/bhs/devilbotz/RobotContainer.java
@@ -32,7 +32,7 @@ public class RobotContainer {
 
   private final HashMap<AutonomousModes, Command> autoCommands = new HashMap<>();
 
-  private final DriveTrain driveTrain = new DriveTrain();
+  public final DriveTrain driveTrain = new DriveTrain();
 
   private final Gripper gripper = new Gripper();
 

--- a/src/main/java/bhs/devilbotz/subsystems/DriveTrain.java
+++ b/src/main/java/bhs/devilbotz/subsystems/DriveTrain.java
@@ -209,7 +209,6 @@ public class DriveTrain extends SubsystemBase {
     // Sets the motor controllers to the correct mode & inverts the right side
     setupTalons();
     // Sets the initial position of the robot to (0, 0) and the initial angle to 0 degrees.
-    resetNavx();
     resetEncoders();
 
     ShuffleboardManager.putField(field);
@@ -232,7 +231,6 @@ public class DriveTrain extends SubsystemBase {
    */
   public void resetOdometry(Pose2d pose) {
     resetEncoders();
-    resetNavx();
     odometry.resetPosition(navx.getRotation2d(), getLeftDistance(), getRightDistance(), pose);
     differentialDriveSim.setPose(pose);
   }

--- a/src/main/java/bhs/devilbotz/subsystems/DriveTrain.java
+++ b/src/main/java/bhs/devilbotz/subsystems/DriveTrain.java
@@ -84,7 +84,7 @@ public class DriveTrain extends SubsystemBase {
           Robot.getSysIdConstant("FEED_FORWARD_LINEAR_A").asDouble());
 
   // Defines the field, which is used to display the robot's position on the field in Shuffleboard.
-  public final Field2d field = new Field2d();
+  private final Field2d field = new Field2d();
 
   // Object for simulated inputs into Talon.
   private static final TalonSRXSimCollection leftMasterSim = leftMaster.getSimCollection();

--- a/src/main/java/bhs/devilbotz/subsystems/DriveTrain.java
+++ b/src/main/java/bhs/devilbotz/subsystems/DriveTrain.java
@@ -14,10 +14,14 @@ import edu.wpi.first.hal.simulation.SimDeviceDataJNI;
 import edu.wpi.first.math.VecBuilder;
 import edu.wpi.first.math.controller.PIDController;
 import edu.wpi.first.math.controller.SimpleMotorFeedforward;
+import edu.wpi.first.math.geometry.Pose2d;
+import edu.wpi.first.math.geometry.Rotation2d;
 import edu.wpi.first.math.kinematics.ChassisSpeeds;
 import edu.wpi.first.math.kinematics.DifferentialDriveKinematics;
 import edu.wpi.first.math.kinematics.DifferentialDriveOdometry;
 import edu.wpi.first.math.kinematics.DifferentialDriveWheelSpeeds;
+import edu.wpi.first.networktables.NetworkTableEntry;
+import edu.wpi.first.networktables.NetworkTableInstance;
 import edu.wpi.first.wpilibj.RobotBase;
 import edu.wpi.first.wpilibj.RobotController;
 import edu.wpi.first.wpilibj.SPI;
@@ -80,7 +84,7 @@ public class DriveTrain extends SubsystemBase {
           Robot.getSysIdConstant("FEED_FORWARD_LINEAR_A").asDouble());
 
   // Defines the field, which is used to display the robot's position on the field in Shuffleboard.
-  private final Field2d field = new Field2d();
+  public final Field2d field = new Field2d();
 
   // Object for simulated inputs into Talon.
   private static final TalonSRXSimCollection leftMasterSim = leftMaster.getSimCollection();
@@ -187,6 +191,15 @@ public class DriveTrain extends SubsystemBase {
     return nativeUnitsToDistanceMeters(10 * sensorCountsPer100ms);
   }
 
+  NetworkTableEntry xSimStart =
+      NetworkTableInstance.getDefault().getTable("Simulation").getEntry("x_start_pose");
+  NetworkTableEntry ySimStart =
+      NetworkTableInstance.getDefault().getTable("Simulation").getEntry("y_start_pose");
+  NetworkTableEntry rotSimStart =
+      NetworkTableInstance.getDefault().getTable("Simulation").getEntry("rot_start_pose");
+  NetworkTableEntry readSimStart =
+      NetworkTableInstance.getDefault().getTable("Simulation").getEntry("read_start_pose");
+
   /**
    * DriveTrain constructor This constructor sets up the drive train.
    *
@@ -205,6 +218,43 @@ public class DriveTrain extends SubsystemBase {
     // robot.
     odometry =
         new DifferentialDriveOdometry(navx.getRotation2d(), getLeftDistance(), getRightDistance());
+
+    xSimStart.setNumber(2.0);
+    ySimStart.setNumber(2.0);
+    rotSimStart.setNumber(0.0);
+    readSimStart.setBoolean(false);
+  }
+
+  /**
+   * Resets the odometry to the specified pose.
+   *
+   * @param pose The pose to which to set the odometry.
+   */
+  public void resetOdometry(Pose2d pose) {
+    resetEncoders();
+    resetNavx();
+    odometry.resetPosition(navx.getRotation2d(), getLeftDistance(), getRightDistance(), pose);
+    differentialDriveSim.setPose(pose);
+  }
+
+  /**
+   * Resets the robot position to pose specified in network tables. Allows a user to choose robot
+   * starting position by entering x, y, and rotation values via Shuffleboard or Smartdashboard.
+   * User must toggle boolean to true to read from network tables. Otherwise the last position of
+   * robot on field is used. A user can also enable Test mode and drag/drop robot around field to
+   * any position.
+   */
+  public void resetRobotPosition() {
+    Pose2d newPose;
+    if (readSimStart.getBoolean(false)) {
+      double x = xSimStart.getDouble(1.0);
+      double y = ySimStart.getDouble(1.0);
+      Rotation2d rot = new Rotation2d(rotSimStart.getDouble(0.0));
+      newPose = new Pose2d(x, y, rot);
+    } else {
+      newPose = field.getRobotPose();
+    }
+    resetOdometry(newPose);
   }
 
   /**


### PR DESCRIPTION
User can enter test mode and drag/drop/rotate robot to any place on field.  Or user can update network table entries to set starting pose.  Add the Simulation table to a tab and add all the entries under the table to the tab.  Use the boolean read_start_pose to ignore/use these network table values.  By default they are ignored. If neither Test mode or these network table entries are used, robot uses last known position on field.