### PR TITLE
Fix default commands for subsystems

### DIFF
--- a/src/main/java/bhs/devilbotz/RobotContainer.java
+++ b/src/main/java/bhs/devilbotz/RobotContainer.java
@@ -7,6 +7,7 @@ package bhs.devilbotz;
 
 import bhs.devilbotz.commands.DriveCommand;
 import bhs.devilbotz.commands.arm.ArmDown;
+import bhs.devilbotz.commands.arm.ArmIdle;
 import bhs.devilbotz.commands.arm.ArmMoveDistance;
 import bhs.devilbotz.commands.arm.ArmStop;
 import bhs.devilbotz.commands.arm.ArmToBottom;
@@ -68,9 +69,17 @@ public class RobotContainer {
   public RobotContainer() {
     // Configure the trigger bindings
     configureBindings();
+
     // For debugging balance PID. Allows setting balance PID values on the fly
     SmartDashboard.putData("Balance PID", balancePid);
     SmartDashboard.putData(driveTrain);
+
+    arm.setDefaultCommand(new ArmIdle(arm));
+    gripper.setDefaultCommand(new GripperIdle(gripper));
+    driveTrain.setDefaultCommand(
+        new DriveCommand(driveTrain, rightJoystick::getY, rightJoystick::getX));
+    // driveTrain.setDefaultCommand(new ArcadeDriveOpenLoop(driveTrain, rightJoystick::getY,
+    // rightJoystick::getX));
   }
   /**
    * Use this method to define your trigger->command mappings. Triggers can be created via the
@@ -82,12 +91,6 @@ public class RobotContainer {
    * joysticks}.
    */
   private void configureBindings() {
-    arm.setDefaultCommand(new ArmStop(arm));
-
-    driveTrain.setDefaultCommand(
-        new DriveCommand(driveTrain, rightJoystick::getY, rightJoystick::getX));
-    // driveTrain.setDefaultCommand(new ArcadeDriveOpenLoop(driveTrain, rightJoystick::getY,
-    // rightJoystick::getX));
 
     new JoystickButton(leftJoystick, 1)
         .toggleOnTrue(new GripperClose(gripper))

--- a/src/main/java/bhs/devilbotz/commands/arm/ArmIdle.java
+++ b/src/main/java/bhs/devilbotz/commands/arm/ArmIdle.java
@@ -7,30 +7,18 @@ package bhs.devilbotz.commands.arm;
 import bhs.devilbotz.subsystems.Arm;
 import edu.wpi.first.wpilibj2.command.CommandBase;
 
-/**
- * This command stops the arm.
- *
- * @since 1/25/2023
- * @author joshuamanoj
- */
-public class ArmStop extends CommandBase {
+public class ArmIdle extends CommandBase {
   private final Arm arm;
 
-  /**
-   * The constructor for the arm stop command.
-   *
-   * @param arm The arm subsystem.
-   */
-  public ArmStop(Arm arm) {
+  /** Creates a new ArmIdle. */
+  public ArmIdle(Arm arm) {
     this.arm = arm;
     addRequirements(arm);
   }
 
   // Called when the command is initially scheduled.
   @Override
-  public void initialize() {
-    arm.stop();
-  }
+  public void initialize() {}
 
   // Called every time the scheduler runs while the command is scheduled.
   @Override
@@ -43,6 +31,6 @@ public class ArmStop extends CommandBase {
   // Returns true when the command should end.
   @Override
   public boolean isFinished() {
-    return true;
+    return false;
   }
 }

--- a/src/main/java/bhs/devilbotz/subsystems/Arm.java
+++ b/src/main/java/bhs/devilbotz/subsystems/Arm.java
@@ -244,7 +244,7 @@ public class Arm extends SubsystemBase {
   public boolean atBottom() {
     // Don't check for exact position, check if position is in some range.
     return (getPosition() >= bottomPosition - positionError
-        || getPosition() <= bottomPosition + positionError);
+        && getPosition() <= bottomPosition + positionError);
   }
 
   /**
@@ -255,7 +255,7 @@ public class Arm extends SubsystemBase {
   public boolean atTop() {
     // Don't check for exact position, check if position is in some range.
     return (getPosition() >= topPosition - positionError
-        || getPosition() <= topPosition + positionError);
+        && getPosition() <= topPosition + positionError);
   }
 
   /**
@@ -267,7 +267,7 @@ public class Arm extends SubsystemBase {
   public boolean atMiddle() {
     // Don't check for exact position, check if position is in some range.
     return (getPosition() >= middlePosition - positionError
-        || getPosition() <= middlePosition + positionError);
+        && getPosition() <= middlePosition + positionError);
   }
 
   /**
@@ -296,7 +296,7 @@ public class Arm extends SubsystemBase {
   public boolean atSubstationPortal() {
     // Don't check for exact position, check if position is in some range.
     return (getPosition() >= portalPosition - positionError
-        || getPosition() <= portalPosition + positionError);
+        && getPosition() <= portalPosition + positionError);
   }
 
   /**


### PR DESCRIPTION
Arm default command should do nothing.  Change the ArmStop command to stop motor once in initialize instead of all the time in execute. This might be why we could not get arm motor to move when using rev tool to drive motor.  The robot code was constantly setting speed to zero.

Add default command for gripper subsystem too.  And move all the default setups into one place, outside the configure trigger binding method.

The GripperIdle cmd calls a stop method on the solenoid.  I have no idea what this does or if we need it.  I did not remove it because I don't know what it does and have no way to test.  When testing on the real robot, might want to check to see if this doesn't anything or not?