### PR TITLE
Misc arm and gripper fixes after Monday night meeting

### DIFF
--- a/src/main/java/bhs/devilbotz/Robot.java
+++ b/src/main/java/bhs/devilbotz/Robot.java
@@ -129,6 +129,12 @@ public class Robot extends TimedRobot {
     if (autonomousCommand != null) {
       autonomousCommand.cancel();
     }
+
+    // Every time the robot is enabled in teleop initialize gripper to same/set position.
+    // We want the gripper to be in same starting position every time
+    // so driver does not have to remember/see what gripper position is.
+    // If there is not enough stored air in tanks then this will do nothing.
+    robotContainer.initGripper();
   }
 
   /** This method is called periodically during operator control. */

--- a/src/main/java/bhs/devilbotz/RobotContainer.java
+++ b/src/main/java/bhs/devilbotz/RobotContainer.java
@@ -34,6 +34,7 @@ import edu.wpi.first.wpilibj.DriverStation.Alliance;
 import edu.wpi.first.wpilibj.Joystick;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import edu.wpi.first.wpilibj2.command.Command;
+import edu.wpi.first.wpilibj2.command.CommandBase;
 import edu.wpi.first.wpilibj2.command.Commands;
 import edu.wpi.first.wpilibj2.command.button.CommandXboxController;
 import edu.wpi.first.wpilibj2.command.button.JoystickButton;
@@ -48,9 +49,9 @@ import edu.wpi.first.wpilibj2.command.button.Trigger;
 public class RobotContainer {
   private final DriveTrain driveTrain = new DriveTrain();
 
-  private final Gripper gripper = new Gripper();
+  private static final Gripper gripper = new Gripper();
 
-  private final Arm arm = new Arm();
+  private static final Arm arm = new Arm();
 
   private final ShuffleboardManager shuffleboardManager = new ShuffleboardManager();
 
@@ -77,6 +78,8 @@ public class RobotContainer {
     SmartDashboard.putData(driveTrain);
 
     arm.setDefaultCommand(new ArmIdle(arm));
+    gripper.setDefaultCommand(new GripperIdle(gripper));
+
     driveTrain.setDefaultCommand(
         new DriveCommand(driveTrain, rightJoystick::getY, rightJoystick::getX));
     // driveTrain.setDefaultCommand(new ArcadeDriveOpenLoop(driveTrain, rightJoystick::getY,
@@ -103,7 +106,9 @@ public class RobotContainer {
 
     new JoystickButton(leftJoystick, 5).whileTrue(new ArmUp(arm)).onFalse(new ArmStop(arm));
 
-    new JoystickButton(leftJoystick, 4).whileTrue(new ArmDown(arm)).onFalse(new ArmStop(arm));
+    new JoystickButton(leftJoystick, 4)
+        .whileTrue(new ArmDown(arm, gripper))
+        .onFalse(new ArmStop(arm));
 
     new JoystickButton(leftJoystick, 6).onTrue(new ArmToTop(arm));
     new JoystickButton(leftJoystick, 7)
@@ -228,5 +233,21 @@ public class RobotContainer {
    */
   public void resetRobotPosition() {
     driveTrain.resetRobotPosition();
+  }
+
+  /**
+   * Initialize gripper to known/same position
+   */
+  public void initGripper() {
+    gripper.close();
+  }
+
+  /**
+   * Create a command to move arm down.  This is a workaround/hack to allow Shuffleboard to add arm movement command that requires both arm and gripper.  The arm Shuffleboard tab is setup in the Arm subsystem which has no idea about the Gripper subsystem.
+   * 
+   * @return command to move arm down
+   */
+  public static CommandBase createArmDownCommand() {
+    return new ArmDown(arm, gripper);
   }
 }

--- a/src/main/java/bhs/devilbotz/RobotContainer.java
+++ b/src/main/java/bhs/devilbotz/RobotContainer.java
@@ -235,16 +235,16 @@ public class RobotContainer {
     driveTrain.resetRobotPosition();
   }
 
-  /**
-   * Initialize gripper to known/same position
-   */
+  /** Initialize gripper to known/same position */
   public void initGripper() {
     gripper.close();
   }
 
   /**
-   * Create a command to move arm down.  This is a workaround/hack to allow Shuffleboard to add arm movement command that requires both arm and gripper.  The arm Shuffleboard tab is setup in the Arm subsystem which has no idea about the Gripper subsystem.
-   * 
+   * Create a command to move arm down. This is a workaround/hack to allow Shuffleboard to add arm
+   * movement command that requires both arm and gripper. The arm Shuffleboard tab is setup in the
+   * Arm subsystem which has no idea about the Gripper subsystem.
+   *
    * @return command to move arm down
    */
   public static CommandBase createArmDownCommand() {

--- a/src/main/java/bhs/devilbotz/commands/arm/ArmDown.java
+++ b/src/main/java/bhs/devilbotz/commands/arm/ArmDown.java
@@ -5,6 +5,7 @@
 package bhs.devilbotz.commands.arm;
 
 import bhs.devilbotz.subsystems.Arm;
+import bhs.devilbotz.subsystems.Gripper;
 import edu.wpi.first.wpilibj2.command.CommandBase;
 
 /**
@@ -15,15 +16,19 @@ import edu.wpi.first.wpilibj2.command.CommandBase;
  */
 public class ArmDown extends CommandBase {
   private final Arm arm;
+  private final Gripper gripper;
 
   /**
    * The constructor for the arm down command.
    *
    * @param arm The arm subsystem.
    */
-  public ArmDown(Arm arm) {
+  public ArmDown(Arm arm, Gripper gripper) {
     this.arm = arm;
+    this.gripper = gripper;
+
     addRequirements(arm);
+    addRequirements(gripper);
   }
 
   // Called when the command is initially scheduled.
@@ -34,6 +39,9 @@ public class ArmDown extends CommandBase {
   @Override
   public void execute() {
     arm.down();
+    if (arm.atGripperClose()) {
+      gripper.close();
+    }
   }
 
   // Called once the command ends or is interrupted.

--- a/src/main/java/bhs/devilbotz/commands/gripper/GripperClose.java
+++ b/src/main/java/bhs/devilbotz/commands/gripper/GripperClose.java
@@ -28,13 +28,13 @@ public class GripperClose extends CommandBase {
 
   // Called when the command is initially scheduled.
   @Override
-  public void initialize() {}
+  public void initialize() {
+    gripper.close();
+  }
 
   // Called every time the scheduler runs while the command is scheduled.
   @Override
-  public void execute() {
-    gripper.close();
-  }
+  public void execute() {}
 
   // Called once the command ends or is interrupted.
   @Override

--- a/src/main/java/bhs/devilbotz/commands/gripper/GripperIdle.java
+++ b/src/main/java/bhs/devilbotz/commands/gripper/GripperIdle.java
@@ -28,9 +28,7 @@ public class GripperIdle extends CommandBase {
 
   // Called when the command is initially scheduled.
   @Override
-  public void initialize() {
-    gripper.stop();
-  }
+  public void initialize() {}
 
   // Called every time the scheduler runs while the command is scheduled.
   @Override

--- a/src/main/java/bhs/devilbotz/commands/gripper/GripperOpen.java
+++ b/src/main/java/bhs/devilbotz/commands/gripper/GripperOpen.java
@@ -28,13 +28,13 @@ public class GripperOpen extends CommandBase {
 
   // Called when the command is initially scheduled.
   @Override
-  public void initialize() {}
+  public void initialize() {
+    gripper.open();
+  }
 
   // Called every time the scheduler runs while the command is scheduled.
   @Override
-  public void execute() {
-    gripper.open();
-  }
+  public void execute() {}
 
   // Called once the command ends or is interrupted.
   @Override

--- a/src/main/java/bhs/devilbotz/subsystems/Arm.java
+++ b/src/main/java/bhs/devilbotz/subsystems/Arm.java
@@ -6,7 +6,7 @@ package bhs.devilbotz.subsystems;
 
 import bhs.devilbotz.Constants;
 import bhs.devilbotz.Constants.ArmConstants;
-import bhs.devilbotz.commands.arm.ArmDown;
+import bhs.devilbotz.RobotContainer;
 import bhs.devilbotz.commands.arm.ArmMoveDistance;
 import bhs.devilbotz.commands.arm.ArmStop;
 import bhs.devilbotz.commands.arm.ArmToBottom;
@@ -89,6 +89,12 @@ public class Arm extends SubsystemBase {
   private final double POSITION_BOTTOM = 258;
   private final double POSITION_PORTAL = 465;
 
+  // Note this value is well above the frame/bumpers, not right above them.  When the arm is moving
+  // down there is momentum and time involved.  You need to
+  // start closing the gripper and give it time to close before the moving arm is near the
+  // frame/bummpers.
+  private final double POSITION_GRIPPER_CLOSE = 190;
+
   /*
    * low cone: 258
    * middle cone: 468
@@ -105,6 +111,7 @@ public class Arm extends SubsystemBase {
   private double middlePosition = POSITION_MIDDLE;
   private double bottomPosition = POSITION_BOTTOM;
   private double portalPosition = POSITION_PORTAL;
+  private double gripperClosePosition = POSITION_GRIPPER_CLOSE;
 
   // When trying to reach a set position, how close is good enough? This value is used to determine
   // that. Smaller value tries to reach closer to target position.  Larger will stop arm further
@@ -283,6 +290,19 @@ public class Arm extends SubsystemBase {
   }
 
   /**
+   * Check if arm is at/nearing position where the gripper needs to be closed. The arm cannot be
+   * fully stowed inside robot unless gripper is closed. We do not want to check/return if the
+   * position is less than the gripper close position. If we did this, then the gripper would never
+   * be able to open while arm is in low positions.
+   *
+   * @return true if at middle position false if not.
+   */
+  public boolean atGripperClose() {
+    return (getPosition() >= gripperClosePosition - positionError
+        && getPosition() <= gripperClosePosition + positionError);
+  }
+
+  /**
    * Check if arm is above middle position based on encoder position.
    *
    * @return true if above middle position false if not.
@@ -339,7 +359,7 @@ public class Arm extends SubsystemBase {
 
     cmdList.add(new ArmStop(this)).withPosition(0, 0);
     cmdList.add(new ArmUp(this)).withPosition(0, 1);
-    cmdList.add(new ArmDown(this)).withPosition(0, 2);
+    cmdList.add(RobotContainer.createArmDownCommand()).withPosition(0, 2);
     cmdList.add(new ArmMoveDistance(this, -10)).withPosition(0, 3);
 
     cmdList.add(new ArmToTop(this)).withPosition(1, 0);

--- a/src/main/java/bhs/devilbotz/subsystems/Gripper.java
+++ b/src/main/java/bhs/devilbotz/subsystems/Gripper.java
@@ -49,7 +49,16 @@ public class Gripper extends SubsystemBase {
     doubleSolenoid.set(Value.kReverse);
   }
 
-  /** This method sets the grippers speed to 0. */
+  /**
+   * This method deactivates the gripper solenoid. It should be ok to leave the solenoid in
+   * fwd/reverse. Reading thru this thread on CD explains why:
+   * https://www.chiefdelphi.com/t/do-you-need-to-set-a-double-solenoid-to-off-after-bringing-it-in/368798
+   * Based on comments in that thread we should be fine leaving the solenoid actuated/firing all the
+   * time. We want do do this to prevent the gripper from flapping if the gate in the solenoid
+   * moves/slips while the robot is moving around. There is also a delay involved to make sure the
+   * solenoid fired before disabling it. This makes the code more complicated. Ff we can get by with
+   * just leaving the solenoid firing all the time we should do so.
+   */
   public void stop() {
     doubleSolenoid.set(Value.kOff);
   }


### PR DESCRIPTION
- Initialize gripper to same state every time robot is enabled
- Automatically close gripper as arm is moving down right before it reaches the frame/bumpers
- Change gripper commands to fire solenoid once in initialize instead of execute.
- Do not call stop method for solenoid, see comment in Gripper.stop method for explanation
- Set default command for Gripper subsystem