### PR TITLE
2023-03-10 bug fixes

### DIFF
--- a/src/main/java/bhs/devilbotz/Constants.java
+++ b/src/main/java/bhs/devilbotz/Constants.java
@@ -103,14 +103,14 @@ public final class Constants {
     public static final int ENCODER_CHANNEL_A_DIO_PORT = 2; // TODO: add what color tape on wire
     public static final int ENCODER_CHANNEL_B_DIO_PORT = 3; // TODO: add what color tape on wire
 
-    public static final double POSITION_TOP = 558; // arm position to score on top goal
-    public static final double POSITION_MIDDLE = 468; // arm position to score in mid goal
+    public static final double POSITION_TOP = 525; // arm position to score on top goal
+    public static final double POSITION_MIDDLE = 450; // arm position to score in mid goal
     public static final double POSITION_BOTTOM = 258; // arm position to score on bottom goal
     //    public static final double POSITION_PORTAL = 465; // arm position to pickup piece from
     // portal
-    public static final double POSITION_DRIVE = 300; // arm position to use when holding a piece
+    public static final double POSITION_DRIVE = 100; // arm position to use when holding a piece
     public static final double POSITION_GRIPPER_CLOSE =
-        190; // When the arm is moving down, the positon when the gripper needs to be closed to
+        80; // When the arm is moving down, the positon when the gripper needs to be closed to
     // avoid crashing into the frame
     public static final double POSITION_SCORING_DELTA =
         -10; // The amount to move the gripper before releasing piece

--- a/src/main/java/bhs/devilbotz/RobotContainer.java
+++ b/src/main/java/bhs/devilbotz/RobotContainer.java
@@ -144,6 +144,8 @@ public class RobotContainer {
 
       new JoystickButton(rightJoystick, 4)
           .onTrue(new ArmMoveDistance(arm, ArmConstants.POSITION_SCORING_DELTA, gripper));
+
+      new JoystickButton(rightJoystick, 5).onTrue(new PickupFromGround(arm, gripper, driveTrain));
     }
     if (false
         == DriverStation.isJoystickConnected(

--- a/src/main/java/bhs/devilbotz/commands/auto/DriveStraightToDock.java
+++ b/src/main/java/bhs/devilbotz/commands/auto/DriveStraightToDock.java
@@ -47,8 +47,14 @@ public class DriveStraightToDock extends DriveStraightPID {
          */
         setMaxSpeed(Robot.getDriveTrainConstant("DOCK_MAX_SPEED_ON_GROUND").asDouble(0.75));
 
-        if ((currentRoll > Robot.getDriveTrainConstant("DOCK_MIN_RAMP_ROLL").asDouble(10))
-            && (currentRoll < Robot.getDriveTrainConstant("DOCK_MAX_RAMP_ROLL").asDouble(15))) {
+        // We use the absolute value of the current roll so that we can approach the ram either
+        // going forward or backwards.
+        if ((Math.abs(currentRoll) > Robot.getDriveTrainConstant("DOCK_MIN_RAMP_ROLL").asDouble(10))
+            && (Math.abs(currentRoll)
+                < Robot.getDriveTrainConstant("DOCK_MAX_RAMP_ROLL").asDouble(15))) {
+          if (0 == onRampCount) {
+            System.out.println("On Ramp?");
+          }
           onRampCount++;
           System.out.println("#### Maybe On Ramp (onRampCount: " + onRampCount + ") ####");
         } else {

--- a/src/main/java/bhs/devilbotz/commands/auto/DriveStraightToDock.java
+++ b/src/main/java/bhs/devilbotz/commands/auto/DriveStraightToDock.java
@@ -52,9 +52,6 @@ public class DriveStraightToDock extends DriveStraightPID {
         if ((Math.abs(currentRoll) > Robot.getDriveTrainConstant("DOCK_MIN_RAMP_ROLL").asDouble(10))
             && (Math.abs(currentRoll)
                 < Robot.getDriveTrainConstant("DOCK_MAX_RAMP_ROLL").asDouble(15))) {
-          if (0 == onRampCount) {
-            System.out.println("On Ramp?");
-          }
           onRampCount++;
           System.out.println("#### Maybe On Ramp (onRampCount: " + onRampCount + ") ####");
         } else {


### PR DESCRIPTION
These are changes resulting from drive practice this past Friday.

We needed to change `POSITION_GRIPPER_CLOSE` to be at a lower arm point because the higher value prevented the driver from fine tuning ground pickup from the front of the robot when the gripper is open. However, One concern I have with changing `POSITION_GRIPPER_CLOSE` is that there isn't much tolerance in terms of when the gripper closes.  We will test this further tonight at WPI, but we need to think about how to implement the proper ArmSafety but also allowing fine tuning near the `POSITION_GRIPPER_CLOSE`.  E.g. have a way to override the auto-close, but that would defeat the purpose.