### PR TITLE
Tweaks to slow down the AutoScore routine

### DIFF
--- a/src/main/java/bhs/devilbotz/commands/assist/AutoScore.java
+++ b/src/main/java/bhs/devilbotz/commands/assist/AutoScore.java
@@ -10,6 +10,7 @@ import bhs.devilbotz.commands.gripper.GripperOpen;
 import bhs.devilbotz.subsystems.Arm;
 import bhs.devilbotz.subsystems.DriveTrain;
 import bhs.devilbotz.subsystems.Gripper;
+import edu.wpi.first.wpilibj2.command.Commands;
 import edu.wpi.first.wpilibj2.command.SequentialCommandGroup;
 
 public class AutoScore extends SequentialCommandGroup {
@@ -24,6 +25,7 @@ public class AutoScore extends SequentialCommandGroup {
    *   <li>move the robot back to the original position
    *   <li>move the arm down slightly
    *   <li>open the gripper
+   *   <li>wait 1 second (for gripper to open and piece to drop)
    * </ol>
    *
    * <i>Note: This command assumes the robot and arm are already positioned and lined up with the
@@ -36,13 +38,14 @@ public class AutoScore extends SequentialCommandGroup {
   public AutoScore(Arm arm, DriveTrain drivetrain, Gripper gripper) {
     super();
     addCommands(CommandDebug.start());
-    addCommands(new DriveStraightPID(drivetrain, -DriveConstants.POSITION_DRIVE_FROM_PORTAL));
+    addCommands(new DriveStraightPID(drivetrain, -DriveConstants.POSITION_DRIVE_FROM_PORTAL, .5));
     addCommands(drivetrain.stopCommand());
     addCommands(new ArmToPosition(arm, ArmConstants.POSITION_TOP, gripper));
-    addCommands(new DriveStraightPID(drivetrain, DriveConstants.POSITION_DRIVE_FROM_PORTAL));
+    addCommands(new DriveStraightPID(drivetrain, DriveConstants.POSITION_DRIVE_FROM_PORTAL, .5));
     addCommands(drivetrain.stopCommand());
     addCommands(new ArmMoveDistance(arm, ArmConstants.POSITION_SCORING_DELTA, gripper));
     addCommands(new GripperOpen(gripper));
+    addCommands(Commands.waitSeconds(1));
     addCommands(CommandDebug.end());
   }
 }

--- a/src/main/java/bhs/devilbotz/commands/auto/Mobility.java
+++ b/src/main/java/bhs/devilbotz/commands/auto/Mobility.java
@@ -23,7 +23,8 @@ public class Mobility extends SequentialCommandGroup {
   public Mobility(DriveTrain drivetrain, double distance) {
     super();
     addCommands(CommandDebug.start());
-    addCommands(new DriveStraightPID(drivetrain, distance));
+    addCommands(new DriveStraightPID(drivetrain, distance, 1));
+    addCommands(drivetrain.stopCommand());
     addCommands(CommandDebug.end());
   }
 }

--- a/src/main/java/bhs/devilbotz/commands/auto/ScoreAndMobility.java
+++ b/src/main/java/bhs/devilbotz/commands/auto/ScoreAndMobility.java
@@ -8,6 +8,7 @@ import bhs.devilbotz.commands.drivetrain.DriveStraightPID;
 import bhs.devilbotz.subsystems.Arm;
 import bhs.devilbotz.subsystems.DriveTrain;
 import bhs.devilbotz.subsystems.Gripper;
+import edu.wpi.first.wpilibj2.command.ParallelCommandGroup;
 import edu.wpi.first.wpilibj2.command.SequentialCommandGroup;
 
 public class ScoreAndMobility extends SequentialCommandGroup {
@@ -44,12 +45,15 @@ public class ScoreAndMobility extends SequentialCommandGroup {
 
     addCommands(CommandDebug.start());
     addCommands(new AutoScore(arm, drivetrain, gripper));
-    addCommands(new DriveStraightPID(drivetrain, -DriveConstants.POSITION_DRIVE_FROM_PORTAL));
-    addCommands(drivetrain.stopCommand());
-    addCommands(new ArmDown(arm, gripper));
-    // Since we are scoring, we always want to drive backwards in the end. Always set negative
-    // distance in case the driver forgets
-    addCommands(new Mobility(drivetrain, -(Math.abs(distance))));
+    // Move back enough to give clearance for the arm to go down
+    addCommands(new DriveStraightPID(drivetrain, -DriveConstants.POSITION_DRIVE_FROM_PORTAL, 1));
+    addCommands(
+        new ParallelCommandGroup(
+            // Move arm all the way down
+            new ArmDown(arm, gripper),
+            // Since we are scoring, we always want to drive backwards in the end. Always set
+            // negative distance in case the driver forgets
+            new Mobility(drivetrain, -(Math.abs(distance)))));
     addCommands(CommandDebug.end());
   }
 }

--- a/src/main/java/bhs/devilbotz/commands/auto/ScoreDockAndEngage.java
+++ b/src/main/java/bhs/devilbotz/commands/auto/ScoreDockAndEngage.java
@@ -8,6 +8,7 @@ import bhs.devilbotz.commands.drivetrain.DriveStraightPID;
 import bhs.devilbotz.subsystems.Arm;
 import bhs.devilbotz.subsystems.DriveTrain;
 import bhs.devilbotz.subsystems.Gripper;
+import edu.wpi.first.wpilibj2.command.ParallelCommandGroup;
 import edu.wpi.first.wpilibj2.command.SequentialCommandGroup;
 
 /**
@@ -38,10 +39,15 @@ public class ScoreDockAndEngage extends SequentialCommandGroup {
 
     addCommands(CommandDebug.start());
     addCommands(new AutoScore(arm, drivetrain, gripper));
-    addCommands(new DriveStraightPID(drivetrain, -DriveConstants.POSITION_DRIVE_FROM_PORTAL));
+    addCommands(new DriveStraightPID(drivetrain, -DriveConstants.POSITION_DRIVE_FROM_PORTAL, 1));
+    addCommands(
+        new ParallelCommandGroup(
+            // Move arm all the way down
+            new ArmDown(arm, gripper),
+            // Since we are scoring, we always want to drive backwards in the end. Always set
+            // negative distance in case the driver forgets
+            new DockAndEngage(drivetrain, -(Math.abs(maxDistance)), startAngle)));
     addCommands(drivetrain.stopCommand());
-    addCommands(new ArmDown(arm, gripper));
-    addCommands(new DockAndEngage(drivetrain, -(Math.abs(maxDistance)), startAngle));
     addCommands(CommandDebug.end());
   }
 }

--- a/src/main/java/bhs/devilbotz/commands/drivetrain/DriveStraightPID.java
+++ b/src/main/java/bhs/devilbotz/commands/drivetrain/DriveStraightPID.java
@@ -49,6 +49,19 @@ public class DriveStraightPID extends CommandBase {
     // Use addRequirements() here to declare subsystem dependencies.
   }
 
+  /**
+   * The constructor for the Drive Straight PID command.
+   *
+   * @param drivetrain The drive train subsystem.
+   * @param distance The distance (in meters) the robot needs to cover.
+   * @param maxSpeed The max speed the robot should travel
+   */
+  public DriveStraightPID(DriveTrain drivetrain, double distance, double maxSpeed) {
+    this(drivetrain, distance);
+
+    this.maxSpeed = maxSpeed;
+  }
+
   // Called when the command is initially scheduled.
   @Override
   public void initialize() {


### PR DESCRIPTION
The AutoScore routine was quite unstable.  In this fix, the main change is to cap the max speed of the robot to prevent overshoot.  After scoring, to save time, in parallel, we move the robot back and put the arm down.